### PR TITLE
Add missing dependency to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ installed on your system in order to build this program:
 * libx11-dev (libx11 on distros based on Arch Linux) (Needed to compile with Qt5 support)
 * itstool (extracts messages from XML files and outputs PO template files, then merges translations from MO files to create translated XML files)
 * gettext
+* libqt5x11extras5-dev
 
 <br/>
 


### PR DESCRIPTION
Lack of libqt5x11extras5-dev on dependencies list.