### PR TITLE
Release deb generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+
+name: Release_actions
+on: release
+
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    - name: Install Dependencies
+      run: sudo apt-get update && sudo apt-get install g++ cmake extra-cmake-modules qttools5-dev qttools5-dev-tools libsdl2-dev libxi-dev libxtst-dev libx11-dev itstool gettext libqt5x11extras5-dev
+    
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Runs a set of commands using the runners shell
+    - name: Build deb file
+      id: create_deb
+      run: |
+        mkdir build && cd ./build
+        cmake ..
+        cpack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,3 +23,10 @@ jobs:
         mkdir build && cd ./build
         cmake ..
         cpack
+
+    #upload generated files to release
+    - name: Upload binaries to release
+      uses: AButler/upload-release-assets@v2.0
+      with:
+        files: ./build/*.deb
+        repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ from [AUR](https://aur.archlinux.org/packages/antimicrox-git/)
 
 
 #### Building deb package
+Already built .deb files are available on [Release Page](https://github.com/juliagoda/antimicroX/releases)
 
 ```
     cd antimicroX


### PR DESCRIPTION
Automates generating and adding .deb file to assets when new release is published.

Uses:
https://github.com/AButler/upload-release-assets