### PR TITLE
Update trigger for type of release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 
 name: Release_actions
-on: release
-
+on:
+  release:
+    types: [published]
+    
 jobs:
   # This workflow contains a single job called "build"
   build:


### PR DESCRIPTION
Release trigger building binaries only when a new release is published
Earlier this was triggered when release wasu published, created and released.