### PR TITLE
Remove problem with resizing icon in "About" window

### DIFF
--- a/src/aboutdialog.ui
+++ b/src/aboutdialog.ui
@@ -37,12 +37,18 @@
      <item>
       <widget class="QLabel" name="label_5">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
        <property name="minimumSize">
+        <size>
+         <width>64</width>
+         <height>64</height>
+        </size>
+       </property>
+       <property name="maximumSize">
         <size>
          <width>64</width>
          <height>64</height>


### PR DESCRIPTION
Fixing this bug:
![Zrzut ekranu z 2020-07-03 17-22-42](https://user-images.githubusercontent.com/45544416/86484497-a289d300-bd56-11ea-9e7b-d80363021a0f.png)
