### PR TITLE
Improve packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -658,6 +658,9 @@ include(InstallRequiredSystemLibraries)
 
 
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Program used to map keyboard keys and mouse controls to a gamepad.")
+set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "AntimicroX is a graphical program used to map keyboard keys and mouse controls to a gamepad. This program is useful for playing PC games using a gamepad that do not have any form of built-in gamepad support. However, you can use this program to control any desktop application with a gamepad.
+
+It is a new fork of discontinued AntiMicro.")
 
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -675,7 +675,7 @@ if(UNIX) #building .deb package
   set(CPACK_DEBIAN_PACKAGE_MAINTAINER "juliagoda")
   set(CPACK_STRIP_FILES "")
   set(CPACK_SOURCE_STRIP_FILES "")
-  set(CPACK_DEBIAN_PACKAGE_DEPENDS "qt5-default, libsdl2-2.0-0, libqt5x11extras5, libc6")
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "qtbase5-dev, libsdl2-2.0-0, libqt5x11extras5, libc6")
   endif()
 
 set(CPACK_PACKAGE_EXECUTABLES "antimicroX" "antimicroX")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -672,7 +672,7 @@ if(UNIX) #building .deb package
   set(CPACK_DEBIAN_PACKAGE_MAINTAINER "juliagoda")
   set(CPACK_STRIP_FILES "")
   set(CPACK_SOURCE_STRIP_FILES "")
-  set(CPACK_DEBIAN_PACKAGE_DEPENDS "qt5-default, libsdl2-2.0-0, libqt5x11extras5")
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "qt5-default, libsdl2-2.0-0, libqt5x11extras5, libc6")
   endif()
 
 set(CPACK_PACKAGE_EXECUTABLES "antimicroX" "antimicroX")

--- a/other/CMakeLists.txt
+++ b/other/CMakeLists.txt
@@ -2,6 +2,6 @@ add_subdirectory(appdata)
 
 add_custom_target(manpage)
 add_custom_command(TARGET manpage PRE_BUILD
-    COMMAND gzip -c "${PROJECT_SOURCE_DIR}/other/antimicroX.1" > "antimicroX.1.gz" VERBATIM
+    COMMAND gzip -c -9 "${PROJECT_SOURCE_DIR}/other/antimicroX.1" > "antimicroX.1.gz" VERBATIM
 )
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/antimicroX.1.gz" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/man/man1")


### PR DESCRIPTION
Some improvements in packaging according to Debain guidelines and usage of `lintian`.
According to lintian there are still some things requiring fixes:
```
$ lintian ./antimicroX-3.0.0-Linux.deb 
E: antimicrox: changelog-file-missing-in-native-package
E: antimicrox: maintainer-address-missing juliagoda
E: antimicrox: no-copyright-file
E: antimicrox: no-shlibs-control-file usr/lib/x86_64-linux-gnu/libantilib.so.1
E: antimicrox: package-must-activate-ldconfig-trigger usr/lib/x86_64-linux-gnu/libantilib.so.1
E: antimicrox: unstripped-binary-or-object usr/bin/antimicroX
E: antimicrox: unstripped-binary-or-object usr/lib/x86_64-linux-gnu/libantilib.so.1
W: antimicrox: desktop-mime-but-no-exec-code usr/share/applications/com.github.juliagoda.antimicroX.desktop
W: antimicrox: extended-description-line-too-long
W: antimicrox: non-dev-pkg-with-shlib-symlink usr/lib/x86_64-linux-gnu/libantilib.so.1 usr/lib/x86_64-linux-gnu/libantilib.so
W: antimicrox: package-contains-timestamped-gzip usr/share/man/man1/antimicroX.1.gz 2020-07-25T19:42:14
W: antimicrox: package-name-doesnt-match-sonames libantilib1
```

But it is nothing urgent, but it would be necessary if we would want to add AntimicroX to Debian repositories.